### PR TITLE
ci: speed up unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
           java-version: "21"
           cache: gradle
 
-      - name: Unit Tests (PR)
+      - name: Unit Tests (Pull Request)
         if: github.event_name == 'pull_request'
         run: ./gradlew testDebugUnitTest --configuration-cache
 
-      - name: Unit Tests + JaCoCo (push)
+      - name: Unit Tests + JaCoCo (Push)
         if: github.event_name == 'push'
         run: ./gradlew testDebugUnitTest jacocoTestReport --configuration-cache
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,16 @@ jobs:
           java-version: "21"
           cache: gradle
 
-      - name: Unit Tests
-        run: ./gradlew testDebugUnitTest jacocoTestReport
+      - name: Unit Tests (PR)
+        if: github.event_name == 'pull_request'
+        run: ./gradlew testDebugUnitTest --configuration-cache
+
+      - name: Unit Tests + JaCoCo (push)
+        if: github.event_name == 'push'
+        run: ./gradlew testDebugUnitTest jacocoTestReport --configuration-cache
 
       - name: Upload JaCoCo Report
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: jacoco-test-report

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,11 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+# Enable build caching and configuration cache for faster CI builds.
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+# When configured, Gradle will run in incubating parallel mode.
+org.gradle.parallel=true
 # Enables namespacing of each library's R class so that its R class includes only the
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library


### PR DESCRIPTION
## Summary

enable Gradle build cache/configuration cache/parallel
- split Unit Tests step: PR runs tests only, push runs tests + JaCoCo
- upload JaCoCo report only on push
