### PR TITLE
chore: unify ExecPlan guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,9 @@
 
 ## ExecPlans
 
-When writing complex features or significant refactors, use an ExecPlan (as described in .agent/PLANS.md) from design to implementation.
+ExecPlan is our shorthand for the execution plan described in `.agent/PLANS.md`.
+When writing complex features or significant refactors, use an ExecPlan from design to implementation.
+Store ExecPlans under `.agent/plans/`.
 
 ## Build, Test, and Development Commands
 
@@ -47,7 +49,3 @@ If Gradle fails with a `JavaVersion.parse 25.0.1` error, activate the configured
 
 - Commits follow Conventional Commits (e.g., `feat:`, `fix(widget):`, `test:`) as seen in `git log`.
 - PRs should include: a short description of behavior change, test results, and screenshots for UI/widget changes.
-
-## Agent-Specific Instructions
-
-- For complex features or significant refactors, create and maintain an ExecPlan per `.agent/PLANS.md` and store it under `.agent/plans/`.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sotayamashita/sioribi) [![CI](https://github.com/sotayamashita/sioribi/actions/workflows/ci.yml/badge.svg)](https://github.com/sotayamashita/sioribi/actions/workflows/ci.yml)
-


### PR DESCRIPTION
## Summary
- unify ExecPlan guidance into a single section in AGENTS.md
- clarify ExecPlan shorthand and storage location
- remove duplicated agent-specific instruction

## Testing
- not run (pre-commit hooks only)