### PR TITLE
feat: add release workflow and Play internal upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
+        with:
+          distribution: corretto
+          java-version: "21"
+          cache: gradle
+
+      - name: Compute version info
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Versioning policy: docs/versioning-policy.md
+          yy=$(date -u +%y)
+          mm=$(date -u +%m)
+          dd=$(date -u +%d)
+          ww=$(( (10#$dd - 1) / 7 + 1 ))
+          ww=$(printf "%02d" "$ww")
+          short_hash=$(git rev-parse --short=7 HEAD)
+          version_prefix="${yy}.${mm}.${ww}"
+          version_name="${version_prefix}.${short_hash}"
+          existing_count=$(git tag -l "v${version_prefix}.*" | wc -l | tr -d ' ')
+          nn=$(printf "%02d" "$existing_count")
+          version_code="${yy}${mm}${ww}${nn}"
+          echo "version_name=${version_name}" >> "$GITHUB_OUTPUT"
+          echo "version_code=${version_code}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare signing keystore
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "${ANDROID_KEYSTORE_BASE64}" | base64 -d > keystore.jks
+          cat > keystore.properties <<EOF
+          storeFile=keystore.jks
+          storePassword=${ANDROID_KEYSTORE_PASSWORD}
+          keyAlias=${ANDROID_KEY_ALIAS}
+          keyPassword=${ANDROID_KEY_PASSWORD}
+          EOF
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+
+      - name: Prepare Play credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p fastlane
+          echo "${GOOGLE_PLAY_JSON_KEY}" > fastlane/google-play-key.json
+        env:
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+
+      - name: Build release APK
+        run: ./gradlew assembleRelease -PversionName="${{ steps.version.outputs.version_name }}" -PversionCode="${{ steps.version.outputs.version_code }}"
+
+      - name: Build release AAB
+        run: ./gradlew bundleRelease -PversionName="${{ steps.version.outputs.version_name }}" -PversionCode="${{ steps.version.outputs.version_code }}"
+
+      - name: Locate APK
+        id: apk
+        shell: bash
+        run: |
+          set -euo pipefail
+          apk_path=$(ls app/build/outputs/apk/release/*.apk 2>/dev/null | head -n 1)
+          if [ -z "${apk_path}" ]; then
+            echo "Release APK not found under app/build/outputs/apk/release/" >&2
+            exit 1
+          fi
+          echo "path=${apk_path}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@de2c0ea772f7dbb18a6ad93cfb65fbee4d3b5ee8 # v2
+        with:
+          tag_name: "v${{ steps.version.outputs.version_name }}"
+          name: "v${{ steps.version.outputs.version_name }}"
+          generate_release_notes: true
+          files: ${{ steps.apk.outputs.path }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@e7168f2713e6a7d2a85ad55bd77fe39d1e8c9c30 # v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Install fastlane
+        run: gem install fastlane -N
+
+      - name: Upload to Play internal testing
+        run: fastlane android internal

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@
 local.properties
 keystore.properties
 *.jks
+*.keystore
+*.p12
+*.pfx
+fastlane/google-play-key.json
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,18 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.detekt)
     id("jacoco")
+}
+
+val keystorePropertiesFile = rootProject.file("keystore.properties")
+val keystoreProperties = Properties()
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 android {
@@ -13,19 +22,36 @@ android {
     }
     buildToolsVersion = "36.1.0"
 
+    val versionNameOverride = project.findProperty("versionName") as String?
+    val versionCodeOverride = (project.findProperty("versionCode") as String?)?.toIntOrNull()
+
     defaultConfig {
         applicationId = "com.example.sioribi"
         minSdk = 26
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = versionCodeOverride ?: 1
+        versionName = versionNameOverride ?: "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    signingConfigs {
+        create("release") {
+            if (keystorePropertiesFile.exists()) {
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+            }
+        }
     }
 
     buildTypes {
         release {
             isMinifyEnabled = false
+            if (keystorePropertiesFile.exists()) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/docs/versioning-policy.md
+++ b/docs/versioning-policy.md
@@ -1,0 +1,50 @@
+# Versioning
+
+This project follows a Google Maps inspired scheme that is easy to read and
+monotonic for Play Store uploads.
+
+## Overview
+
+- versionName: `YY.MM.WW.<git short hash>`
+- versionCode: `YYMMWWnn`
+- Tag: `v<versionName>`
+
+## Definitions
+
+- `YY`: two-digit year (e.g., 2026 -> 26)
+- `MM`: two-digit month (01-12)
+- `WW`: two-digit week-of-month (01-05)
+- `<git short hash>`: 7-character short commit hash (e.g., `a1b2c3d`)
+- `nn`: two-digit sequence number for releases within the same `YY.MM.WW`
+
+## Rules
+
+1. `versionCode` must be strictly increasing for every Play upload.
+2. `versionName` is for humans; it includes the short git hash to identify the
+   exact commit.
+3. `versionCode` is numeric only and encodes the release time period plus a
+   weekly sequence.
+4. Tags must match the version name with a `v` prefix.
+
+## Examples
+
+- First release of the first week in January 2026
+  - versionName: `26.01.01.a1b2c3d`
+  - versionCode: `26010100`
+  - tag: `v26.01.01.a1b2c3d`
+
+- Third release in the second week of March 2026
+  - versionName: `26.03.02.f00ba42`
+  - versionCode: `26030202`
+  - tag: `v26.03.02.f00ba42`
+
+## Week-of-month
+
+Week-of-month uses the calendar week within the month and is formatted as
+`01-05`. The pipeline determines the week based on the release date in UTC.
+
+## Notes
+
+- If multiple releases happen in the same week, increment `nn` by 1 each time.
+- If the calculated `versionCode` would not be strictly increasing, increment
+  `nn` until it is.

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,1 @@
+package_name("com.example.sioribi")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,16 @@
+default_platform(:android)
+
+platform :android do
+  desc "Upload AAB to Google Play internal testing"
+  lane :internal do
+    upload_to_play_store(
+      track: "internal",
+      aab: "app/build/outputs/bundle/release/app-release.aab",
+      json_key: "fastlane/google-play-key.json",
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+      release_status: "completed"
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- add a manual Release workflow that builds APK/AAB, creates a GitHub Release, and uploads to the Play internal track via fastlane
- support versionName/versionCode overrides and release signing in Gradle
- document the versioning policy and add fastlane configuration

## Testing
- secretlint
- spotless check
- detekt
- unit tests
